### PR TITLE
Update Telegram token config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+TELEGRAM_BOT_TOKEN=your_bot_token_here

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ npm install
 This project includes a Telegram bot service that can echo messages back to users. To use this feature, you need to:
 
 1. Create a Telegram bot using [BotFather](https://t.me/botfather) and obtain your bot token
-2. Set the token as an environment variable:
+2. Set the token as an environment variable named `TELEGRAM_BOT_TOKEN`:
 
 ```bash
 # For Linux/macOS

--- a/src/service/telegram.service.ts
+++ b/src/service/telegram.service.ts
@@ -51,9 +51,9 @@ export class TelegramService implements OnModuleInit {
 
   constructor() {
     // Initialize the bot with the token from environment variable
-    const botToken = process.env.BOT_KEY;
+    const botToken = process.env.TELEGRAM_BOT_TOKEN;
     if (!botToken) {
-      throw new Error('BOT_KEY environment variable is not set');
+      throw new Error('TELEGRAM_BOT_TOKEN environment variable is not set');
     }
     this.bot = new TelegramBot(botToken, { polling: true });
 


### PR DESCRIPTION
## Summary
- rename `BOT_KEY` to `TELEGRAM_BOT_TOKEN`
- document env var name in README
- include example `.env.example`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495d7196fc8326b532239d7fbdd831